### PR TITLE
Adding a getClassMap method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 matrix:
   include:
-  - php: 7.2
+  - php: 7.4
     env: PREFER_LOWEST=""
   - php: 7.1
     env: PREFER_LOWEST=""

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
         "php-coveralls/php-coveralls": "^2.1",
         "phpunit/phpunit": "^7.2.7",
         "squizlabs/php_codesniffer": "^3.2.3",
-        "phpstan/phpstan": "^0.10.3",
+        "phpstan/phpstan": "^0.12",
         "maglnet/composer-require-checker": "^1.0",
-        "thecodingmachine/phpstan-strict-rules": "^0.11.0",
+        "thecodingmachine/phpstan-strict-rules": "^0.12",
         "symfony/cache": "^4.1.4"
     },
     "autoload": {
@@ -45,7 +45,7 @@
     "scripts": {
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
-        "phpstan": "phpstan analyse src -c phpstan.neon --level=7 --no-progress -vvv"
+        "phpstan": "phpstan analyse src -c phpstan.neon --level=8 --no-progress -vvv"
     },
     "minimum-stability": "alpha",
     "prefer-stable": true

--- a/src/Glob/GlobClassExplorer.php
+++ b/src/Glob/GlobClassExplorer.php
@@ -112,7 +112,7 @@ class GlobClassExplorer implements ClassExplorerInterface
 
     /**
      * @param string $directory
-     * @return \Iterator
+     * @return \Iterator<string>
      */
     private function getPhpFilesForDir(string $directory): \Iterator
     {

--- a/src/Glob/GlobClassExplorer.php
+++ b/src/Glob/GlobClassExplorer.php
@@ -3,6 +3,8 @@
 
 namespace TheCodingMachine\ClassExplorer\Glob;
 
+use SplFileInfo;
+use function array_keys;
 use function chdir;
 use DirectoryIterator;
 use GlobIterator;
@@ -66,14 +68,24 @@ class GlobClassExplorer implements ClassExplorerInterface
     /**
      * Returns an array of fully qualified class names.
      *
-     * @return string[]
+     * @return array<int,string>
      */
     public function getClasses(): array
+    {
+        return array_keys($this->getClassMap());
+    }
+
+    /**
+     * Returns an array mapping the fully qualified class name to the file path.
+     *
+     * @return array<string,SplFileInfo>
+     */
+    public function getClassMap(): array
     {
         $key = 'globClassExplorer_'.str_replace('\\', '_', $this->namespace);
         $classes = $this->cache->get($key);
         if ($classes === null) {
-            $classes = $this->doGetClasses();
+            $classes = $this->doGetClassMap();
             $this->cache->set($key, $classes, $this->cacheTtl);
         }
         return $classes;
@@ -82,9 +94,9 @@ class GlobClassExplorer implements ClassExplorerInterface
     /**
      * Returns an array of fully qualified class names, without the cache.
      *
-     * @return string[]
+     * @return array<string,SplFileInfo>
      */
-    private function doGetClasses(): array
+    private function doGetClassMap(): array
     {
         $namespace = trim($this->namespace, '\\').'\\';
         if ($this->classNameMapper === null) {
@@ -103,7 +115,7 @@ class GlobClassExplorer implements ClassExplorerInterface
             foreach ($filesForDir as $file) {
                 // Trim the root directory name and the PHP extension
                 $fileTrimPrefixSuffix = \substr($file, $dirLen, -4);
-                $classes[] = $namespace.\str_replace('/', '\\', $fileTrimPrefixSuffix);
+                $classes[$namespace.\str_replace('/', '\\', $fileTrimPrefixSuffix)] = $file;
             }
         }
         chdir($oldCwd);
@@ -112,7 +124,7 @@ class GlobClassExplorer implements ClassExplorerInterface
 
     /**
      * @param string $directory
-     * @return \Iterator<string>
+     * @return \Iterator<SplFileInfo>
      */
     private function getPhpFilesForDir(string $directory): \Iterator
     {

--- a/tests/Glob/GlobClassExplorerTest.php
+++ b/tests/Glob/GlobClassExplorerTest.php
@@ -40,4 +40,13 @@ class GlobClassExplorerTest extends TestCase
 
         $this->assertSame([], $classes);
     }
+
+    public function testGetClassMap()
+    {
+        $explorer = new GlobClassExplorer('\\TheCodingMachine\\ClassExplorer\\', new NullCache(), null, null, true, __DIR__.'/../..');
+        $classMap = $explorer->getClassMap();
+
+        $this->assertArrayHasKey(GlobClassExplorer::class, $classMap);
+        $this->assertSame('src/Glob/GlobClassExplorer.php', (string) $classMap[GlobClassExplorer::class]);
+    }
 }


### PR DESCRIPTION
This method allows fetching a class map (mapping the class to the file) rather than only fetching a list of classes.
This can be useful for loading the files without resorting to an autoloader (or for generating an autoloader)
