### PR TITLE
Changing the return type of getClassMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ $explorer = new GlobClassExplorer('\\This\\Namespace\\Only\\', $psr16Cache, $cac
 
 You can also get a class map using the `getClassMap` method.
 A class map is an array associating the name of the classes found (in key), to the file they are 
-linked to (a `SplFileInfo` in value).
+linked to (the real path of the file).
 
 ```php
 $classMap = $explorer->getClassMap();
-foreach ($classMap as $class => $fileInfo) {
-    echo 'Class '.$class.' found in file '.$fileInfo->getPathname();
+foreach ($classMap as $class => $file) {
+    echo 'Class '.$class.' found in file '.$file;
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require": {
     	"php": ">=7.1",
         "psr/simple-cache": "^1",
-        "mouf/classname-mapper": "^1"
+        "mouf/classname-mapper": "^1",
+        "ext-hash": "*"
     },
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.1",

--- a/tests/Glob/GlobClassExplorerTest.php
+++ b/tests/Glob/GlobClassExplorerTest.php
@@ -47,6 +47,6 @@ class GlobClassExplorerTest extends TestCase
         $classMap = $explorer->getClassMap();
 
         $this->assertArrayHasKey(GlobClassExplorer::class, $classMap);
-        $this->assertSame('src/Glob/GlobClassExplorer.php', (string) $classMap[GlobClassExplorer::class]);
+        $this->assertStringEndsWith('src/Glob/GlobClassExplorer.php', (string) $classMap[GlobClassExplorer::class]);
     }
 }


### PR DESCRIPTION
Because SplFileInfo class is not serializable.
Fallback to full path as a string