### PR TITLE
Support autoload dev namespaces

### DIFF
--- a/src/Glob/GlobClassExplorer.php
+++ b/src/Glob/GlobClassExplorer.php
@@ -70,8 +70,7 @@ class GlobClassExplorer implements ClassExplorerInterface
         ?ClassNameMapper $classNameMapper = null,
         bool $recursive = true,
         ?string $rootPath = null
-    )
-    {
+    ) {
         $this->namespace = $namespace;
         $this->cache = $cache;
         $this->cacheTtl = $cacheTtl;
@@ -111,7 +110,7 @@ class GlobClassExplorer implements ClassExplorerInterface
     /**
      * Set to true to get classes in composer autoload-dev namespaces
      *
-     * @return $this
+     * @return void
      */
     public function setUseAutoloadDev(bool $useAutoloadDev)
     {
@@ -121,7 +120,7 @@ class GlobClassExplorer implements ClassExplorerInterface
     /**
      * Returns an array of fully qualified class names, without the cache.
      *
-     * @return array<string,string>
+     * @return array<string,string|false>
      */
     private function doGetClassMap(): array
     {

--- a/tests/Glob/GlobClassExplorerTest.php
+++ b/tests/Glob/GlobClassExplorerTest.php
@@ -13,8 +13,8 @@ class GlobClassExplorerTest extends TestCase
     {
         $explorer = new GlobClassExplorer('\\TheCodingMachine\\ClassExplorer\\', new NullCache(), null, null, true, __DIR__.'/../..');
         $classes = $explorer->getClasses();
-
-        $this->assertSame([GlobClassExplorer::class, ClassExplorerInterface::class], $classes);
+        $this->assertTrue(in_array(GlobClassExplorer::class, $classes));
+        $this->assertTrue(in_array(ClassExplorerInterface::class, $classes));
     }
 
     public function testGetClassesNonRecursive()

--- a/tests/Glob/GlobClassExplorerTest.php
+++ b/tests/Glob/GlobClassExplorerTest.php
@@ -49,4 +49,14 @@ class GlobClassExplorerTest extends TestCase
         $this->assertArrayHasKey(GlobClassExplorer::class, $classMap);
         $this->assertStringEndsWith('src/Glob/GlobClassExplorer.php', (string) $classMap[GlobClassExplorer::class]);
     }
+
+    public function testGetClassesDev()
+    {
+        $explorer = new GlobClassExplorer('\\TheCodingMachine\\ClassExplorer\\', new NullCache(), null, null, true, __DIR__.'/../..');
+        $explorer->setUseAutoloadDev(true);
+        $classes = $explorer->getClasses();
+        $this->assertTrue(in_array(GlobClassExplorer::class, $classes));
+        $this->assertTrue(in_array(ClassExplorerInterface::class, $classes));
+        $this->assertTrue(in_array(GlobClassExplorerTest::class, $classes));
+    }
 }


### PR DESCRIPTION
Supports loading namespaces from `autoload-dev`. I couldn't use your library with unit tests because it wouldn't load my tests/App. Also cleaned up some code a bit and made the unit tests work again.

Usage:

```php
$explorer = new GlobClassExplorer($namespace, new NullCache());
$explorer->setUseAutoloadDev(true);
$classes = $explorer->getClasses();
```